### PR TITLE
Add configuration for laod test machine

### DIFF
--- a/buildmachine/README.md
+++ b/buildmachine/README.md
@@ -35,6 +35,17 @@ Skript má nasledovné parametre (všetky nepovinné):
 - `-ScriptsPath` – cesta, kde sa nakopírujú skripty pre údržbu systému. Predvolená hdonota je `C:\scripts`,
 - `-CachePath` – cesta, kde sa nastaví keš pre rôzne programy (NPM, Cypress…). Predvolená hodnota je `C:\cache`.
 
+## Script `install-load-tests.ps1`
+
+Skript nainštaluje / nakonfiguruje všetko potrebné pre load testy. Tento script je potrebné spúšťať len na build mašinách, ktoré budú spúšťať load testy. Nainštaluje software, ktorý je definovaný v `load-tests-buildmachine-packages.config`. Taktiež stiahne a rozbalí JMeter *(by default do `C:\tools\jmeter`)* a nainštaluje potrebné plugins.
+
+Skript má nasledovné parametre (všetky nepovinné):
+
+- `JMeterVersion` - Verzia JMeter-u, ktorá sa má nainštalovať. *(default je `5.4.1`)*
+- `DownloadFolder` - Adresár, do ktorého sa dočasne stiahne JMeter. *(default je `C:\download`)*
+- `JMeterPath` - Adresár, kam sa nakopíruje Jmeter. *(default je `C:\tools\jmeter`)*
+- `PluginsList` - Čiarkou oddelený zoznam pluginov *(Plugin Id)*, ktoré sa majú nainštalovať. *(default je `jpgc-graphs-basic,jpgc-casutg,jpgc-prmctl`)*
+
 ## PowerShell (`install.ps1`)
 
 Je potrebné povoliť spúšťanie skriptov: `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope LocalMachine`.

--- a/buildmachine/README.md
+++ b/buildmachine/README.md
@@ -42,8 +42,7 @@ Skript nainštaluje / nakonfiguruje všetko potrebné pre load testy. Tento scri
 Skript má nasledovné parametre (všetky nepovinné):
 
 - `JMeterVersion` - Verzia JMeter-u, ktorá sa má nainštalovať. *(default je `5.4.1`)*
-- `DownloadFolder` - Adresár, do ktorého sa dočasne stiahne JMeter. *(default je `C:\download`)*
-- `JMeterPath` - Adresár, kam sa nakopíruje Jmeter. *(default je `C:\tools\jmeter`)*
+- `ToolsPath` - Adresár, kde sa nachádzajú naše tools. Tam sa nainštaluje JMeter. *(default je `C:\tools`)*
 - `PluginsList` - Čiarkou oddelený zoznam pluginov *(Plugin Id)*, ktoré sa majú nainštalovať. *(default je `jpgc-graphs-basic,jpgc-casutg,jpgc-prmctl`)*
 
 ## PowerShell (`install.ps1`)

--- a/buildmachine/buildmachine-packages.config
+++ b/buildmachine/buildmachine-packages.config
@@ -17,7 +17,6 @@ Ak v budúcnosti pribudne ďalší build počítač, nech vieme jednoducho nain�
 	<package id="nuget.commandline" />
 	<package id="postman" />
 	<package id="terraform" />
-	<package id="7zip" />
 
 	<package id="dotnetcore-sdk" />
 	<package id="nodejs-lts" />

--- a/buildmachine/buildmachine-packages.config
+++ b/buildmachine/buildmachine-packages.config
@@ -17,6 +17,7 @@ Ak v budúcnosti pribudne ďalší build počítač, nech vieme jednoducho nain�
 	<package id="nuget.commandline" />
 	<package id="postman" />
 	<package id="terraform" />
+	<package id="7zip" />
 
 	<package id="dotnetcore-sdk" />
 	<package id="nodejs-lts" />

--- a/buildmachine/install-load-tests.ps1
+++ b/buildmachine/install-load-tests.ps1
@@ -1,0 +1,100 @@
+#Requires -RunAsAdministrator
+
+[CmdletBinding()]
+param (
+    [Parameter()][string]$JMeterVersion = "5.4.1",
+    [Parameter()][string]$DownloadFolder = "C:\download",
+    [Parameter()][string]$JMeterPath = "C:\tools\jmeter",
+    [Parameter()][string]$PluginsList = "jpgc-graphs-basic,jpgc-casutg,jpgc-prmctl"
+)
+
+function ExtractArchive([string]$archiveFile, [string]$outputFolder) {
+    Write-Host "    Extract archive '$archiveFile' to '$outputFolder'" -ForegroundColor Blue
+
+    $extractCommand = "7z x $archiveFile -o$jmeterSource -r -aoa"
+    Invoke-Expression $extractCommand
+}
+
+function AddToPath([string]$path) {
+	Write-Host "  Add '$path' to environment variable PATH" -ForegroundColor Yellow
+	$pathValue = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
+	$pattern = $path.Replace("\", "\\")
+	if ($pathValue -match $pattern) {
+		Write-Host "    PATH variable already contains '$path'."
+	}
+	else {
+		$pathValue = "$path;" + $pathValue
+		[System.Environment]::SetEnvironmentVariable("PATH", $pathValue, [System.EnvironmentVariableTarget]::Machine)
+		Write-Host "    '$path' added to PATH variable."
+	}
+}
+
+# Choco install
+Write-Host "Install software for load testing" -ForegroundColor Green
+choco install load-tests-buildmachine-packages.config --yes
+
+# Add JAVA folder to PATH
+Write-Host "Add JAVA folder to PATH" -ForegroundColor Green
+$javaHomeValue = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::Machine)
+if ([string]::IsNullOrEmpty($javaHomeValue)) {
+    Write-Host "    'JAVA_HOME' is not set, so Java variables will not be set ('JAVA', 'JAVA_FLAGS', 'SONAR_SCANNER_OPTS')."
+}
+else {
+    $javaBinPath = Join-Path -Path $javaHomeValue -ChildPath "bin"
+    AddToPath $javaBinPath
+}
+
+# Install JMeter
+Write-Host "Install JMeter" -ForegroundColor Green
+
+$jmeterSource = Join-Path -Path $DownloadFolder -ChildPath "jmeter"
+$jmeterZipFile = Join-Path -Path $jmeterSource -ChildPath "jmeter.tgz"
+$tarFile = Join-Path -Path $jmeterSource -ChildPath "jmeter.tar"
+$extractedFolder = Join-Path -Path $jmeterSource -ChildPath "apache-jmeter-$JMeterVersion"
+$pluginManagerFile = Join-Path -Path $JMeterPath -ChildPath "lib/ext/jmeter-plugins-manage.jar"
+$cmdRunnerFile = Join-Path -Path $JMeterPath -ChildPath "lib/cmdrunner-2.2.jar"
+
+## Delete source and target folder
+Write-Host "  Delete JMeter folder '$JMeterPath'" -ForegroundColor Yellow
+Remove-Item $JMeterPath -Recurse -ErrorAction Ignore
+Remove-Item $jmeterSource -Recurse -ErrorAction Ignore
+
+## Download JMeter
+Write-Host "  Download JMeter (v $JMeterVersion)" -ForegroundColor Yellow
+Invoke-WebRequest -Uri "https://downloads.apache.org//jmeter/binaries/apache-jmeter-$JMeterVersion.tgz" -OutFile ( New-Item -Path $jmeterZipFile -Force)
+
+## Extract JMeter
+Write-Host "  Extract downloaded JMeter" -ForegroundColor Green
+ExtractArchive $jmeterZipFile $jmeterSource
+ExtractArchive $tarFile $jmeterSource
+
+## Copy extracted JMeter to dest folder
+Write-Host "  Copy JMeter from '$extractedFolder' to '$JMeterPath'" -ForegroundColor Green
+Move-Item "$extractedFolder*" $JMeterPath
+
+$jmeterBinPath = Join-Path -Path $JMeterPath -ChildPath "bin"
+AddToPath $jmeterBinPath
+
+## Delete source
+Write-Host "  Delete source folder '$jmeterSource'" -ForegroundColor Yellow
+Remove-Item $jmeterSource -Recurse -ErrorAction Ignore
+
+# Install JMeter plugins
+## Download and install Plugin manager
+Write-Host "Install JMeter plugins" -ForegroundColor Green
+Write-Host "  Download and install Plugin manager" -ForegroundColor Yellow
+Invoke-WebRequest -Uri "https://jmeter-plugins.org/get/" -OutFile ( New-Item -Path $pluginManagerFile -Force)
+Invoke-WebRequest -Uri "https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar" -OutFile ( New-Item -Path $cmdRunnerFile -Force)
+
+## Create PluginManagerCMDInstaller
+Write-Host "  Create PluginManagerCMDInstaller" -ForegroundColor Yellow
+java -cp $JMeterPath/lib/ext/jmeter-plugins-manage.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+
+Write-Host "  Install plugins" -ForegroundColor Yellow
+$pluginManagerCmd = Join-Path -Path $JMeterPath -ChildPath "bin/PluginsManagerCMD.bat"
+$cmd = "$pluginManagerCmd install $PluginsList"
+Invoke-Expression $cmd
+
+
+Write-Host
+Write-Host "  Everything is installed. Now run the 'configure.ps1' script." -ForegroundColor Yellow

--- a/buildmachine/install-load-tests.ps1
+++ b/buildmachine/install-load-tests.ps1
@@ -3,17 +3,9 @@
 [CmdletBinding()]
 param (
     [Parameter()][string]$JMeterVersion = "5.4.1",
-    [Parameter()][string]$DownloadFolder = "C:\download",
-    [Parameter()][string]$JMeterPath = "C:\tools\jmeter",
+    [Parameter()][string]$ToolsPath = "C:\tools",
     [Parameter()][string]$PluginsList = "jpgc-graphs-basic,jpgc-casutg,jpgc-prmctl"
 )
-
-function ExtractArchive([string]$archiveFile, [string]$outputFolder) {
-    Write-Host "    Extract archive '$archiveFile' to '$outputFolder'" -ForegroundColor Blue
-
-    $extractCommand = "7z x $archiveFile -o$jmeterSource -r -aoa"
-    Invoke-Expression $extractCommand
-}
 
 function AddToPath([string]$path) {
 	Write-Host "  Add '$path' to environment variable PATH" -ForegroundColor Yellow
@@ -37,7 +29,7 @@ choco install load-tests-buildmachine-packages.config --yes
 Write-Host "Add JAVA folder to PATH" -ForegroundColor Green
 $javaHomeValue = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::Machine)
 if ([string]::IsNullOrEmpty($javaHomeValue)) {
-    Write-Host "    'JAVA_HOME' is not set, so Java variables will not be set ('JAVA', 'JAVA_FLAGS', 'SONAR_SCANNER_OPTS')."
+    Write-Host "    'JAVA_HOME' is not set, so Java folder will not be set to the PATH."
 }
 else {
     $javaBinPath = Join-Path -Path $javaHomeValue -ChildPath "bin"
@@ -47,51 +39,45 @@ else {
 # Install JMeter
 Write-Host "Install JMeter" -ForegroundColor Green
 
-$jmeterSource = Join-Path -Path $DownloadFolder -ChildPath "jmeter"
-$jmeterZipFile = Join-Path -Path $jmeterSource -ChildPath "jmeter.tgz"
-$tarFile = Join-Path -Path $jmeterSource -ChildPath "jmeter.tar"
-$extractedFolder = Join-Path -Path $jmeterSource -ChildPath "apache-jmeter-$JMeterVersion"
-$pluginManagerFile = Join-Path -Path $JMeterPath -ChildPath "lib/ext/jmeter-plugins-manage.jar"
-$cmdRunnerFile = Join-Path -Path $JMeterPath -ChildPath "lib/cmdrunner-2.2.jar"
+$jmeterPath = Join-Path -Path $ToolsPath -ChildPath "jmeter"
+$jmeterZipFile = Join-Path -Path $env:TEMP -ChildPath "jmeter.zip"
+$extractedFolder = Join-Path -Path $ToolsPath -ChildPath "apache-jmeter-$JMeterVersion"
+$pluginManagerFile = Join-Path -Path $jmeterPath -ChildPath "lib/ext/jmeter-plugins-manage.jar"
+$cmdRunnerFile = Join-Path -Path $jmeterPath -ChildPath "lib/cmdrunner-2.2.jar"
 
-## Delete source and target folder
-Write-Host "  Delete JMeter folder '$JMeterPath'" -ForegroundColor Yellow
-Remove-Item $JMeterPath -Recurse -ErrorAction Ignore
-Remove-Item $jmeterSource -Recurse -ErrorAction Ignore
+## Delete target folder
+Write-Host "  Delete JMeter folder '$jmeterPath'" -ForegroundColor Yellow
+Remove-Item $jmeterPath -Recurse -ErrorAction Ignore
 
 ## Download JMeter
 Write-Host "  Download JMeter (v $JMeterVersion)" -ForegroundColor Yellow
-Invoke-WebRequest -Uri "https://downloads.apache.org//jmeter/binaries/apache-jmeter-$JMeterVersion.tgz" -OutFile ( New-Item -Path $jmeterZipFile -Force)
+Invoke-WebRequest -Uri "https://downloads.apache.org/jmeter/binaries/apache-jmeter-$JMeterVersion.zip" -OutFile $jmeterZipFile
 
 ## Extract JMeter
 Write-Host "  Extract downloaded JMeter" -ForegroundColor Green
-ExtractArchive $jmeterZipFile $jmeterSource
-ExtractArchive $tarFile $jmeterSource
+Expand-Archive -Path $jmeterZipFile -DestinationPath $ToolsPath
+Rename-Item $extractedFolder $jmeterPath
 
-## Copy extracted JMeter to dest folder
-Write-Host "  Copy JMeter from '$extractedFolder' to '$JMeterPath'" -ForegroundColor Green
-Move-Item "$extractedFolder*" $JMeterPath
-
-$jmeterBinPath = Join-Path -Path $JMeterPath -ChildPath "bin"
+$jmeterBinPath = Join-Path -Path $jmeterPath -ChildPath "bin"
 AddToPath $jmeterBinPath
 
 ## Delete source
-Write-Host "  Delete source folder '$jmeterSource'" -ForegroundColor Yellow
-Remove-Item $jmeterSource -Recurse -ErrorAction Ignore
+Write-Host "  Delete source file '$jmeterZipFile'" -ForegroundColor Yellow
+Remove-Item $jmeterZipFile -Recurse -ErrorAction Ignore
 
 # Install JMeter plugins
 ## Download and install Plugin manager
 Write-Host "Install JMeter plugins" -ForegroundColor Green
 Write-Host "  Download and install Plugin manager" -ForegroundColor Yellow
-Invoke-WebRequest -Uri "https://jmeter-plugins.org/get/" -OutFile ( New-Item -Path $pluginManagerFile -Force)
-Invoke-WebRequest -Uri "https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar" -OutFile ( New-Item -Path $cmdRunnerFile -Force)
+Invoke-WebRequest -Uri "https://jmeter-plugins.org/get/" -OutFile $pluginManagerFile
+Invoke-WebRequest -Uri "https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar" -OutFile $cmdRunnerFile
 
 ## Create PluginManagerCMDInstaller
 Write-Host "  Create PluginManagerCMDInstaller" -ForegroundColor Yellow
-java -cp $JMeterPath/lib/ext/jmeter-plugins-manage.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+java -cp $pluginManagerFile org.jmeterplugins.repository.PluginManagerCMDInstaller
 
 Write-Host "  Install plugins" -ForegroundColor Yellow
-$pluginManagerCmd = Join-Path -Path $JMeterPath -ChildPath "bin/PluginsManagerCMD.bat"
+$pluginManagerCmd = Join-Path -Path $jmeterPath -ChildPath "bin/PluginsManagerCMD.bat"
 $cmd = "$pluginManagerCmd install $PluginsList"
 Invoke-Expression $cmd
 

--- a/buildmachine/install.ps1
+++ b/buildmachine/install.ps1
@@ -11,4 +11,4 @@ Write-Host "Install software" -ForegroundColor Yellow
 choco install buildmachine-packages.config --yes
 
 Write-Host
-Write-Host "Everything is installed. Now run the 'configure.ps1' script." -ForegroundColor Green
+Write-Host "Everything is installed. If you want install software for load testing, then run the 'install-load-tests.ps1' otherwise  run the 'configure.ps1' script." -ForegroundColor Green

--- a/buildmachine/load-tests-buildmachine-packages.config
+++ b/buildmachine/load-tests-buildmachine-packages.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Zoznam programov, ktoré sa inštalujú na build počítač, ktorý spúšťa load pipeline-y na load testy.
+-->
+<packages>
+	<package id="openjdk" />
+</packages>

--- a/buildmachine/load-tests-buildmachine-packages.config
+++ b/buildmachine/load-tests-buildmachine-packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Zoznam programov, ktoré sa inštalujú na build počítač, ktorý spúšťa load pipeline-y na load testy.
+Zoznam programov, ktoré sa inštalujú na build počítač, ktorý spúšťa pipeline-y na load testy.
 -->
 <packages>
 	<package id="openjdk" />


### PR DESCRIPTION
Pribudol nám ďalší typ agentov, a to agenti pre load testy. 
Tento PR pridáva `install-load-tests.ps1` script, ktorý vie dokonfigurovať mašinu, na ktorej budú bežať títo agenti.

---
## Script `install-load-tests.ps1`

Skript nainštaluje / nakonfiguruje všetko potrebné pre load testy. Tento script je potrebné spúšťať len na build mašinách, ktoré budú spúšťať load testy. Nainštaluje software, ktorý je definovaný v `load-tests-buildmachine-packages.config`. Taktiež stiahne a rozbalí JMeter *(by default do `C:\tools\jmeter`)* a nainštaluje potrebné plugins.

Skript má nasledovné parametre (všetky nepovinné):

- `JMeterVersion` - Verzia JMeter-u, ktorá sa má nainštalovať. *(default je `5.4.1`)*
- `DownloadFolder` - Adresár, do ktorého sa dočasne stiahne JMeter. *(default je `C:\download`)*
- `JMeterPath` - Adresár, kam sa nakopíruje Jmeter. *(default je `C:\tools\jmeter`)*
- `PluginsList` - Čiarkou oddelený zoznam pluginov *(Plugin Id)*, ktoré sa majú nainštalovať. *(default je `jpgc-graphs-basic,jpgc-casutg,jpgc-prmctl`)*
