### PR TITLE
Docker users and startup

### DIFF
--- a/buildmachine/README.md
+++ b/buildmachine/README.md
@@ -218,7 +218,15 @@ Docker je potrebné nainštalovať "ručne". Najskôr je v programoch a súčast
 
 Ďalej [nainštalovať linux subsystem](https://docs.microsoft.com/en-us/windows/wsl/install) `wsl --install`.
 
-A nakoniec samotný [Docker](https://docs.docker.com/desktop/windows/install/).
+Následne samotný [Docker](https://docs.docker.com/desktop/windows/install/).
+
+### Nastavenie spúšťania
+
+`Docker desktop.exe` sa spúšťa až s prihlásením používateľa *(po odhlásení sa vypne)*. Je potrebné naplánovať udalosť po štarte mašiny, ktorá ho spustí.
+Je na to vytvorený script `.\register-docker-start-schedule.ps1 "username" "password"`. Je potrebné zadať používateľa pod ktorým sa to bude spúšťať.
+
+Taktiež je potrebné pridať všetkých používateľov _(pod ktorými bežia agenti)_ do skupiny `docker-users` _(aby mali prístup k docker daemon-u)_.
+Na to je tiež vytvorený script `.\add-users-to-docker-group.ps1 "esw" 15 1`.
 
 ## Čistenie dočasných (temp) súborov (`configure.ps1`)
 

--- a/buildmachine/add-users-to-docker-group.ps1
+++ b/buildmachine/add-users-to-docker-group.ps1
@@ -2,30 +2,20 @@
 
 [CmdletBinding()]
 param (
-	[Parameter()][string]$UserName,
-	[Parameter()][int]$NumberOfUsers,
+	[Parameter(Mandatory = $true)][string]$UserName,
+	[Parameter(Mandatory = $true)][int]$NumberOfUsers,
 	[Parameter()][int]$StartUserNumber = 1
 )
 
 $userNameMaxLength = 15
-if ([string]::IsNullOrWhiteSpace($UserName)) {
-	$UserName = Read-Host -Prompt 'User name'
-}
 if (-not ($UserName -match "^[a-z0-9_-]{1,$userNameMaxLength}$")) {
 	throw "Invalid user name. It must be a string containig only letters, numbers, underscore (_) and hyphen (-) and its maximum length can be $userNameMaxLength characters."
 }
-if ($NumberOfUsers -lt 1) {
-	$NumberOfUsers = [int](Read-Host -Prompt 'Number of users')
-	if ($NumberOfUsers -lt 1) {
-		throw "Invalid number of users. It must be number greater or equal to 1."
-	}
-}
-else {
-	Write-Host "UserName = $UserName"
-	Write-Host "NumberOfUsers = $NumberOfUsers"
-	$StartUserNumber..($StartUserNumber + $NumberOfUsers - 1) | ForEach-Object {
-		$localUserName = "a-{0}-{1:d2}" -f $UserName, $_
-		Write-Host "Add user '$localUserName' to 'docker-users' group."
-        Add-LocalGroupMember -Group docker-users -Member $localUserName -ErrorAction Stop
-	}
+
+Write-Host "UserName = $UserName"
+Write-Host "NumberOfUsers = $NumberOfUsers"
+$StartUserNumber..($StartUserNumber + $NumberOfUsers - 1) | ForEach-Object {
+	$localUserName = "a-{0}-{1:d2}" -f $UserName, $_
+	Write-Host "Add user '$localUserName' to 'docker-users' group."
+	Add-LocalGroupMember -Group docker-users -Member $localUserName -ErrorAction Stop
 }

--- a/buildmachine/add-users-to-docker-group.ps1
+++ b/buildmachine/add-users-to-docker-group.ps1
@@ -1,0 +1,31 @@
+#Requires -RunAsAdministrator
+
+[CmdletBinding()]
+param (
+	[Parameter()][string]$UserName,
+	[Parameter()][int]$NumberOfUsers,
+	[Parameter()][int]$StartUserNumber = 1
+)
+
+$userNameMaxLength = 15
+if ([string]::IsNullOrWhiteSpace($UserName)) {
+	$UserName = Read-Host -Prompt 'User name'
+}
+if (-not ($UserName -match "^[a-z0-9_-]{1,$userNameMaxLength}$")) {
+	throw "Invalid user name. It must be a string containig only letters, numbers, underscore (_) and hyphen (-) and its maximum length can be $userNameMaxLength characters."
+}
+if ($NumberOfUsers -lt 1) {
+	$NumberOfUsers = [int](Read-Host -Prompt 'Number of users')
+	if ($NumberOfUsers -lt 1) {
+		throw "Invalid number of users. It must be number greater or equal to 1."
+	}
+}
+else {
+	Write-Host "UserName = $UserName"
+	Write-Host "NumberOfUsers = $NumberOfUsers"
+	$StartUserNumber..($StartUserNumber + $NumberOfUsers - 1) | ForEach-Object {
+		$localUserName = "a-{0}-{1:d2}" -f $UserName, $_
+		Write-Host "Add user '$localUserName' to 'docker-users' group."
+        Add-LocalGroupMember -Group docker-users -Member $localUserName -ErrorAction Stop
+	}
+}

--- a/buildmachine/create-users.ps1
+++ b/buildmachine/create-users.ps1
@@ -2,31 +2,22 @@
 
 [CmdletBinding()]
 param (
-	[Parameter()][string]$UserName,
-	[Parameter()][int]$NumberOfUsers,
+	[Parameter(Mandatory = $true)][string]$UserName,
+	[Parameter(Mandatory = $true)][int]$NumberOfUsers,
 	[Parameter()][int]$StartUserNumber = 1
 )
 
 $userNameMaxLength = 15
-if ([string]::IsNullOrWhiteSpace($UserName)) {
-	$UserName = Read-Host -Prompt 'User name'
-}
+
 if (-not ($UserName -match "^[a-z0-9_-]{1,$userNameMaxLength}$")) {
 	throw "Invalid user name. It must be a string containig only letters, numbers, underscore (_) and hyphen (-) and its maximum length can be $userNameMaxLength characters."
 }
-if ($NumberOfUsers -lt 1) {
-	$NumberOfUsers = [int](Read-Host -Prompt 'Number of users')
-	if ($NumberOfUsers -lt 1) {
-		throw "Invalid number of users. It must be number greater or equal to 1."
-	}
-}
-else {
-	Write-Host "UserName = $UserName"
-	Write-Host "NumberOfUsers = $NumberOfUsers"
-	$StartUserNumber..($StartUserNumber + $NumberOfUsers - 1) | ForEach-Object {
-		$localUserName = "a-{0}-{1:d2}" -f $UserName, $_
-		$password = ConvertTo-SecureString -String $localUserName -AsPlainText
-		Write-Host "Creating user: $localUserName"
-		New-LocalUser -Name $localUserName -FullName $localUserName -Description "Account for DevOps build agent." -Password $password -PasswordNeverExpires -UserMayNotChangePassword -AccountNeverExpires
-	}
+
+Write-Host "UserName = $UserName"
+Write-Host "NumberOfUsers = $NumberOfUsers"
+$StartUserNumber..($StartUserNumber + $NumberOfUsers - 1) | ForEach-Object {
+	$localUserName = "a-{0}-{1:d2}" -f $UserName, $_
+	$password = ConvertTo-SecureString -String $localUserName -AsPlainText
+	Write-Host "Creating user: $localUserName"
+	New-LocalUser -Name $localUserName -FullName $localUserName -Description "Account for DevOps build agent." -Password $password -PasswordNeverExpires -UserMayNotChangePassword -AccountNeverExpires
 }

--- a/buildmachine/register-docker-start-schedule.ps1
+++ b/buildmachine/register-docker-start-schedule.ps1
@@ -1,0 +1,12 @@
+#Requires -RunAsAdministrator
+
+[CmdletBinding()]
+param (
+	[Parameter(Mandatory = $true)][string]$UserName,
+	[Parameter(Mandatory = $true)][SecureString]$UserPassword
+)
+
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$action = New-ScheduledTaskAction -Execute "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+$settings = New-ScheduledTaskSettingsSet -Compatibility Win8 -AllowStartIfOnBatteries
+Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "KROS - Start Docker on Start up" -Settings $settings -User $UserName -Password $UserPassword -RunLevel Highest


### PR DESCRIPTION
Popis a scripty pre nastavenie spúštania `Docker desktop.exe` a pridanie používateľov do skupiny `docker-users`.

> Script `add-users-to-docker-group.ps1` je do veľkej miery kópia scriptu `create-users.ps1`. Nie je to možné spúšťať spoločne a kombinovať to do jedného scriptu, respektíve rozdeľovať to ešte na viac scriptov mi prišlo ako zbytočné. Ale nechám sa presvedčiť 😉